### PR TITLE
Fix parameter parsing

### DIFF
--- a/arcadia/Position.h
+++ b/arcadia/Position.h
@@ -1072,7 +1072,7 @@ public:
     void fillRank(int rank, string currentRank) {
         int rankStart = 10 * (rank + 1);
         int next = rankStart + 1;
-        for (int i = 0; i < currentRank.length(); i++) {
+        for (size_t i = 0; i < currentRank.length(); i++) {
             char currChar = currentRank[i];
             if (Character::isDigit(currChar)) {
                 int digit = Character::getNumericValue(currChar);

--- a/arcadia/main.cpp
+++ b/arcadia/main.cpp
@@ -222,9 +222,10 @@ int extractIntValue(string parameters, string s){
 		return 0;
 	}
 	size_t searchFrom = index + s.length() + 1;
-	string extracted = parameters.substr(searchFrom);
-	string first = split(extracted,' ')[0];
-	return stoi(extracted);
+        string extracted = parameters.substr(searchFrom);
+        string first = split(extracted,' ')[0];
+        // Only parse the first whitespace-separated token
+        return stoi(first);
 }
 void parse(string toParse) {
 	// for debugging


### PR DESCRIPTION
## Summary
- avoid parsing whole string when extracting ints
- fix signedness warning in `fillRank`

## Testing
- `g++ -std=c++11 -Wall arcadia/*.cpp -o arcadia/a.out`