### PR TITLE
Add Autotools steps to CI

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,6 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Install Autotools
+      run: sudo apt-get install -y autoconf automake
+    - name: Generate configure script
+      run: autoreconf -i
     - name: configure
       run: ./configure
     - name: make


### PR DESCRIPTION
## Summary
- update CI workflow to install Autotools and generate the `configure` script prior to running `configure`

## Testing
- `git log -1 --stat`